### PR TITLE
Update "IPython" to "Jupyter Notebook"

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 
 *Interactive Python interpreters (REPL).*
 
-* [IPython](https://github.com/ipython/ipython) - A rich toolkit to help you make the most out of using Python interactively.
+* [Jupyter Notebook](https://github.com/jupyter/notebook) - (Formerly IPython) A rich toolkit to help you make the most out of using Python interactively.
 * [bpython](http://bpython-interpreter.org) – A fancy interface to the Python interpreter.
 * [ptpython](https://github.com/jonathanslenders/ptpython) - Advanced Python REPL built on top of the [python-prompt-toolkit](https://github.com/jonathanslenders/python-prompt-toolkit).
 


### PR DESCRIPTION
# Text to update
- [Jupyter Notebook](https://github.com/jupyter/notebook) - (Formerly IPython) A rich toolkit to help you make the most out of using Python interactively.
# Reason for change:

From https://ipython.org/

> Jupyter and the future of IPython
> 
> IPython is a growing project, with increasingly language-agnostic components. IPython 3.x was the last monolithic release of IPython, containing the notebook server, qtconsole, etc. As of IPython 4.0, the language-agnostic parts of the project: the notebook format, message protocol, qtconsole, notebook web application, etc. have moved to new projects under the name Jupyter. IPython itself is focused on interactive Python, part of which is providing a Python kernel for Jupyter.

From https://jupyter.org/about.html

> About Project Jupyter
> 
> Project Jupyter was born out of the IPython Project in 2014 as it evolved to support interactive data science and scientific computing across all programming languages.
# Reccomendation

We should keep IPython on this line to avoid confusion.  Jupyter is the new version of IPython, but IPython is probably still more widely recognized.
